### PR TITLE
Support multistroke definitions

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -127,7 +127,7 @@ proxy "/definitions.html", "definition-list.html",
   locals: { definitions: definition_list }, ignore: true
 
 definition_list.each do |definition|
-  synonyms = data.definitions.select { |defn| defn.word == definition.word }
+  synonyms = definition_list.select { |defn| defn.word == definition.word }
 
   if homograph_words = homograph_dictionary[definition.word]
     homographs = homograph_words.flat_map do |word|

--- a/config.rb
+++ b/config.rb
@@ -16,18 +16,14 @@ if data.has_key?(:bricks) && data.has_key?(:definitions)
     brickset.add(brick)
   end
 
-  definition_list = data.definitions.sort_by(&:word).map do |definition|
-    {
-      word: definition.word,
-      chord: mapper.lookup(definition.bricks),
-      bricks: definition.bricks.map { |name| brickset.lookup(name) }
-    }
+  definition_list = data.definitions.sort_by(&:word).map do |data|
+    Steno::Definition.new(data, brickset, mapper)
   end
 
   definition_list.each do |definition|
-    next if definition[:word] == '[' || definition[:word] == ']'
-    wordset[definition[:word]] ||= []
-    wordset[definition[:word]] << definition
+    next if definition.word == '[' || definition.word == ']'
+    wordset[definition.word] ||= []
+    wordset[definition.word] << definition
   end
 else
   abort "Cannot build site without data"
@@ -124,9 +120,9 @@ if data.has_key? :bricks
 end
 
 definition_list.each do |definition|
-  synonyms = data.definitions.select { |defn| defn.word == definition[:word] }
+  synonyms = data.definitions.select { |defn| defn.word == definition.word }
 
-  if homograph_words = homograph_dictionary[definition[:word]]
+  if homograph_words = homograph_dictionary[definition.word]
     homographs = homograph_words.flat_map do |word|
       data.definitions.select { |defn| defn.word == word }
     end
@@ -134,10 +130,10 @@ definition_list.each do |definition|
     homographs = []
   end
 
-  proxy "/definitions/#{definition[:chord]}.svg", "/definition.svg",
+  proxy "/definitions/#{definition.notation}.svg", "/definition.svg",
     locals: { definition: definition }, ignore: true
 
-  proxy "/definitions/#{definition[:chord]}.html", "/definition.html",
+  proxy "/definitions/#{definition.notation}.html", "/definition.html",
     locals: { definition: definition, synonyms: synonyms, homographs: homographs }, ignore: true
 end
 

--- a/config.rb
+++ b/config.rb
@@ -108,7 +108,7 @@ end
 
 if data.has_key? :bricks
   data.bricks.each do |brick|
-    definitions = data.definitions.select { |defn| defn.bricks.include?(brick.id) }
+    definitions = definition_list.select { |defn| defn.bricks.include?(brick.id) }
     similar = (data.bricks - [brick]).select { |b| b.keystrokes == brick.keystrokes }
 
     proxy "/bricks/#{brick.id}.svg", "/brick.svg",

--- a/config.rb
+++ b/config.rb
@@ -119,6 +119,13 @@ if data.has_key? :bricks
   end
 end
 
+# Strange but true: the definition_list defined in this file is made available
+# to proxy pages, but for some reason it is not available to normal pages.
+# That's why we're doing this slightly awkward dance to make the
+# definition_list availble in the definitions.html page
+proxy "/definitions.html", "definition-list.html",
+  locals: { definitions: definition_list }, ignore: true
+
 definition_list.each do |definition|
   synonyms = data.definitions.select { |defn| defn.word == definition.word }
 

--- a/config.rb
+++ b/config.rb
@@ -19,7 +19,7 @@ if data.has_key?(:bricks) && data.has_key?(:definitions)
   definition_list = data.definitions.sort_by(&:word).map do |definition|
     {
       word: definition.word,
-      chord: mapper.lookup(definition),
+      chord: mapper.lookup(definition.bricks),
       bricks: definition.bricks.map { |name| brickset.lookup(name) }
     }
   end

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -2872,6 +2872,13 @@
     ]
   },
   {
+    "word": "being",
+    "chords": [
+      { "bricks": [ "end-b" ] },
+      { "bricks": [ "end-g" ] }
+    ]
+  },
+  {
     "word": "bee",
     "bricks": [
       "start-b",

--- a/helpers/site_helper.rb
+++ b/helpers/site_helper.rb
@@ -1,10 +1,11 @@
 require 'cgi'
 
 module SiteHelper
+  # Note: rootpath is set in config.rb
+
   def link_to_definition(definition)
-    # mapper and rootpath are set in config.rb
-    chord = mapper.lookup(definition.bricks)
-    link_to chord, "#{rootpath}/definitions/#{chord}/"
+    notation = definition.notation
+    link_to notation, "#{rootpath}/definitions/#{notation}/"
   end
 
   def link_to_word(word)

--- a/helpers/site_helper.rb
+++ b/helpers/site_helper.rb
@@ -3,7 +3,7 @@ require 'cgi'
 module SiteHelper
   def link_to_definition(definition)
     # mapper and rootpath are set in config.rb
-    chord = mapper.lookup(definition)
+    chord = mapper.lookup(definition[:bricks])
     link_to chord, "#{rootpath}/definitions/#{chord}/"
   end
 

--- a/helpers/site_helper.rb
+++ b/helpers/site_helper.rb
@@ -3,7 +3,7 @@ require 'cgi'
 module SiteHelper
   def link_to_definition(definition)
     # mapper and rootpath are set in config.rb
-    chord = mapper.lookup(definition[:bricks])
+    chord = mapper.lookup(definition.bricks)
     link_to chord, "#{rootpath}/definitions/#{chord}/"
   end
 

--- a/lib/brick_mapper.rb
+++ b/lib/brick_mapper.rb
@@ -15,6 +15,7 @@ class BrickMapper
   end
 
   def lookup(bricks)
+    bricks = bricks.map { |b| b.respond_to?(:id) ? b.id : b }
     keyNumbers = bricks_to_numbers(bricks)
 
     [

--- a/lib/brick_mapper.rb
+++ b/lib/brick_mapper.rb
@@ -14,8 +14,7 @@ class BrickMapper
     end
   end
 
-  def lookup(definition)
-    bricks = definition.fetch("bricks", definition[:bricks])
+  def lookup(bricks)
     keyNumbers = bricks_to_numbers(bricks)
 
     [

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -95,8 +95,8 @@ module Steno
   end
 
   class Chord
-    attr_reader :bricks, :foundation, :overlay
-    def initialize(bricks, registry=BrickRegistry.new)
+    attr_reader :bricks, :notation, :foundation, :overlay
+    def initialize(bricks, registry=BrickRegistry.new, mapper=nil)
       bricks = bricks.map { |b|
         if b.class == Brick
           b
@@ -106,6 +106,9 @@ module Steno
       }
       @bricks = bricks.sort_by { |b| b.keystrokes.last }
       detect_overlaps
+      if mapper
+        @notation = mapper.lookup(@bricks.map(&:id))
+      end
     end
 
     def eql?(other)

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -145,6 +145,10 @@ module Steno
     def notation
       @chords.map(&:notation).join("/")
     end
+
+    def bricks
+      @chords.map(&:bricks).flatten.uniq
+    end
   end
 
 end

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -134,8 +134,9 @@ module Steno
 
     def initialize(params, registry=BrickRegistry.new, mapper=nil)
       params = OpenStruct.new(params)
+      params.chords ||= []
       if params.bricks
-        params.chords = [{ bricks: params.bricks }]
+        params.chords << { bricks: params.bricks }
       end
 
       @word   = params.word

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -132,14 +132,14 @@ module Steno
   class Definition
     attr_reader :word, :chords
 
-    def initialize(params)
+    def initialize(params, registry=BrickRegistry.new, mapper=nil)
       params = OpenStruct.new(params)
       @word = params.word
 
       if params.chords
-        @chords = params.chords
+        @chords = params.chords.map { |chord| Chord.new(chord[:bricks], registry, mapper) }
       else
-        @chords = [params.bricks]
+        @chords = [Chord.new(params.bricks, registry, mapper)]
       end
     end
   end

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -142,6 +142,10 @@ module Steno
         @chords = [Chord.new(params.bricks, registry, mapper)]
       end
     end
+
+    def notation
+      @chords.map(&:notation).join("/")
+    end
   end
 
 end

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'ostruct'
 require_relative './steno_keyboard'
 
 module Steno
@@ -110,6 +111,21 @@ module Steno
           @overlay = @overlay - [one]
           @foundation << FoundationBrick.new(one.id, one.label, one.keystrokes, two)
         end
+      end
+    end
+  end
+
+  class Definition
+    attr_reader :word, :chords
+
+    def initialize(params)
+      params = OpenStruct.new(params)
+      @word = params.word
+
+      if params.chords
+        @chords = params.chords
+      else
+        @chords = [params.bricks]
       end
     end
   end

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -96,9 +96,20 @@ module Steno
 
   class Chord
     attr_reader :bricks, :foundation, :overlay
-    def initialize(bricks)
+    def initialize(bricks, registry=BrickRegistry.new)
+      bricks = bricks.map { |b|
+        if b.class == Brick
+          b
+        else
+          registry.lookup(b)
+        end
+      }
       @bricks = bricks.sort_by { |b| b.keystrokes.last }
       detect_overlaps
+    end
+
+    def eql?(other)
+      @bricks.zip(other.bricks).all? { |mine, yours| mine == yours }
     end
 
     private

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -134,13 +134,12 @@ module Steno
 
     def initialize(params, registry=BrickRegistry.new, mapper=nil)
       params = OpenStruct.new(params)
-      @word = params.word
-
-      if params.chords
-        @chords = params.chords.map { |chord| Chord.new(chord[:bricks], registry, mapper) }
-      else
-        @chords = [Chord.new(params.bricks, registry, mapper)]
+      if params.bricks
+        params.chords = [{ bricks: params.bricks }]
       end
+
+      @word   = params.word
+      @chords = params.chords.map { |chord| Chord.new(chord[:bricks], registry, mapper) }
     end
 
     def notation

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -9,7 +9,12 @@ class Validator
   end
 
   def used_bricks
-    @definitions.flat_map { |d| d['bricks'] }.uniq
+    @definitions.flat_map { |definition|
+      definition['strokes'] ||= [
+        { 'bricks' => definition['bricks'] }
+      ]
+      definition['strokes'].flat_map { |stroke| stroke['bricks'] }
+    }.compact.uniq
   end
 
   def undefined_bricks

--- a/source/_definitions-table.html.erb
+++ b/source/_definitions-table.html.erb
@@ -7,7 +7,7 @@
   </tr>
 
   <% definitions.each do |definition| %>
-    <% highlight = mapper.lookup(definition) == active[:chord] %>
+    <% highlight = mapper.lookup(definition[:bricks]) == active[:chord] %>
     <tr class="<%= highlight ? 'active' : '' %>">
       <td class="input"><%= link_to_definition(definition) %></td>
       <td class="output"><%= definition.word %></td>

--- a/source/_definitions-table.html.erb
+++ b/source/_definitions-table.html.erb
@@ -7,7 +7,7 @@
   </tr>
 
   <% definitions.each do |definition| %>
-    <% highlight = mapper.lookup(definition.bricks) == active.notation %>
+    <% highlight = definition.notation == active.notation %>
     <tr class="<%= highlight ? 'active' : '' %>">
       <td class="input"><%= link_to_definition(definition) %></td>
       <td class="output"><%= definition.word %></td>

--- a/source/_definitions-table.html.erb
+++ b/source/_definitions-table.html.erb
@@ -1,4 +1,4 @@
-<% active ||= {} %>
+<% active ||= OpenStruct.new({}) %>
 
 <table>
   <tr>
@@ -7,7 +7,7 @@
   </tr>
 
   <% definitions.each do |definition| %>
-    <% highlight = mapper.lookup(definition[:bricks]) == active[:chord] %>
+    <% highlight = mapper.lookup(definition.bricks) == active.notation %>
     <tr class="<%= highlight ? 'active' : '' %>">
       <td class="input"><%= link_to_definition(definition) %></td>
       <td class="output"><%= definition.word %></td>

--- a/source/definition-list.html.erb
+++ b/source/definition-list.html.erb
@@ -1,0 +1,5 @@
+---
+title: Steno Definitions
+---
+
+<%= partial('definitions-table', locals: {definitions: definitions}) %>

--- a/source/definition.html.erb
+++ b/source/definition.html.erb
@@ -2,13 +2,13 @@
 title: Definition page
 ---
 
-<h1 class="definition-title"><%= definition[:word] %></h1>
+<h1 class="definition-title"><%= definition.word %></h1>
 
-<img src="<%= path_to_svg(definition[:chord], "definitions") %>"/>
+<img src="<%= path_to_svg(definition.notation, "definitions") %>"/>
 
 <h2>Bricks</h2>
 
-<%= partial('brick-list', locals: {bricks: definition[:bricks]}) %>
+<%= partial('brick-list', locals: {bricks: definition.bricks}) %>
 
 <% unless homographs.empty? %>
   <h2>Homographs</h2>
@@ -21,7 +21,7 @@ title: Definition page
 <% if synonyms.length > 1 %>
   <h2>Synonyms</h2>
 
-  <p>We can produce the output "<%= definition[:word] %>" using any of these definitions:</p>
+  <p>We can produce the output "<%= definition.word %>" using any of these definitions:</p>
 
   <%= partial('definitions-table', locals: {definitions: synonyms, active: definition}) %>
 <% end %>

--- a/source/definition.svg.builder
+++ b/source/definition.svg.builder
@@ -4,12 +4,14 @@ title: Steno Bricks Diagram
 viewBox: "0 0 1350 500"
 ---
 
-chord = Steno::Chord.new(definition[:bricks])
+definition.chords.each do |chord|
 
-chord.foundation.each do |brick|
-  xml << partial('brick', locals: {brick: brick})
-end
+  chord.foundation.each do |brick|
+    xml << partial('brick', locals: {brick: brick})
+  end
 
-chord.overlay.each do |brick|
-  xml << partial('brick', locals: {brick: brick})
+  chord.overlay.each do |brick|
+    xml << partial('brick', locals: {brick: brick})
+  end
+
 end

--- a/source/definitions.html.erb
+++ b/source/definitions.html.erb
@@ -1,5 +1,0 @@
----
-title: Steno Definitions
----
-
-<%= partial('definitions-table', locals: {definitions: data.definitions.sort_by(&:word)}) %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,7 +10,7 @@
     <% if defined?(brick) %>
       <title><%= current_page.data.title %>: <%= brick.label %></title>
     <% elsif defined?(definition) %>
-      <title><%= (definition[:chord]).upcase %>: <%= definition[:word] %></title>
+      <title><%= (definition.notation).upcase %>: <%= definition.word %></title>
     <% else %>
       <title><%= current_page.data.title %></title>
     <% end %>

--- a/source/word.html.erb
+++ b/source/word.html.erb
@@ -5,5 +5,5 @@ title: Word page
 <h1 class="word-title"><%= word %></h1>
 
 <% definitions.each do |definition| %>
-  <img src="<%= path_to_svg(definition[:chord], "definitions") %>"/>
+  <img src="<%= path_to_svg(definition.notation, "definitions") %>"/>
 <% end %>

--- a/spec/brick_mapper_spec.rb
+++ b/spec/brick_mapper_spec.rb
@@ -113,29 +113,29 @@ describe BrickMapper do
 
   context 'definitions with a vowel (or star)' do
     it "converts 'car' to kar" do
-      expect(mapper.lookup(car)).to eql('kar')
+      expect(mapper.lookup(car[:bricks])).to eql('kar')
     end
 
     it "converts 'bar' to pwar" do
-      expect(mapper.lookup(bar)).to eql('pwar')
+      expect(mapper.lookup(bar[:bricks])).to eql('pwar')
     end
 
     it "converts 'earth' to *ert" do
-      expect(mapper.lookup(earth)).to eql('*ert')
+      expect(mapper.lookup(earth[:bricks])).to eql('*ert')
     end
   end
 
   context 'definitions with no vowel (or star)' do
     it "converts 'about' to 'PW'" do
-      expect(mapper.lookup(about)).to eql('pw')
+      expect(mapper.lookup(about[:bricks])).to eql('pw')
     end
 
     it "converts 'the' to '-T'" do
-      expect(mapper.lookup(the)).to eql('-t')
+      expect(mapper.lookup(the[:bricks])).to eql('-t')
     end
 
     it "converts 'been' to 'PW-PB'" do
-      expect(mapper.lookup(been)).to eql('pw-pb')
+      expect(mapper.lookup(been[:bricks])).to eql('pw-pb')
     end
   end
 

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -228,6 +228,13 @@ module Steno
         expect(two_stroke.word).to eql('being')
         expect(two_stroke.chords.count).to eql(2)
       end
+
+      describe '#notation' do
+        it 'creates notation from it\'s constituent bricks' do
+          expect(mono_stroke.notation).to eql('-b')
+          expect(two_stroke.notation).to eql('-b/-g')
+        end
+      end
     end
   end
 end

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -235,6 +235,13 @@ module Steno
           expect(two_stroke.notation).to eql('-b/-g')
         end
       end
+
+      describe '#bricks' do
+        it 'lists all bricks used by this definition' do
+          expect(mono_stroke.bricks).to eql([end_b])
+          expect(two_stroke.bricks).to eql([end_b, end_g])
+        end
+      end
     end
   end
 end

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -114,8 +114,9 @@ module Steno
     end
 
     describe Chord do
+      let(:registry) { double("BrickRegistry") }
+      let(:mapper)   { double('BrickMapper') }
       describe 'construction' do
-        let(:registry) { double("BrickRegistry") }
         before do
           allow(registry).to receive(:lookup).with('soft-e').and_return(soft_e)
           allow(registry).to receive(:lookup).with('start-b').and_return(start_b)
@@ -125,6 +126,18 @@ module Steno
           one = Chord.new(['start-b', 'soft-e', 'end-nch'], registry)
           two = Chord.new([start_b, soft_e, end_nch])
           expect(one).to eql(two)
+        end
+      end
+
+      describe '#notation' do
+        subject(:bench) { Chord.new([start_b, soft_e, end_nch], registry, mapper) }
+        before do
+          allow(mapper).to receive(:lookup)
+            .with(['start-b', 'soft-e', 'end-nch'])
+            .and_return('pwefrpb')
+        end
+        it 'uses mapper to look up notation' do
+          expect(bench.notation).to eql('pwefrpb')
         end
       end
 

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -3,10 +3,14 @@ require_relative '../lib/steno'
 
 module Steno
   describe 'Steno' do
+    let(:registry) { double("BrickRegistry") }
+    let(:mapper)   { double('BrickMapper') }
     let(:start_d) { Brick.new('start-d', 'd',   [2, 3]) }
     let(:start_b) { Brick.new('start-b', 'b',   [4, 5]) }
     let(:star)    { Brick.new('star', '*',   [10]) }
     let(:soft_e)  { Brick.new('soft-e', 'e',   [11]) }
+    let(:end_b)   { Brick.new('end-b', 'b',  [16]) }
+    let(:end_g)   { Brick.new('end-g', 'g',  [18]) }
     let(:end_th)  { Brick.new('end-th', 'th',  [10, 19]) }
     let(:end_nch) { Brick.new('end-nch', 'nch', [13, 14, 15, 16]) }
 
@@ -114,8 +118,6 @@ module Steno
     end
 
     describe Chord do
-      let(:registry) { double("BrickRegistry") }
-      let(:mapper)   { double('BrickMapper') }
       describe 'construction' do
         before do
           allow(registry).to receive(:lookup).with('soft-e').and_return(soft_e)
@@ -183,44 +185,49 @@ module Steno
     end
 
     describe Definition do
-      let(:flat_mono) { {
+      let(:flat_mono_constructor) { {
         "word": "be",
         "bricks": ["end-b"]
       } }
+      subject(:flat_mono) { Definition.new(flat_mono_constructor, registry, mapper) }
 
-      let(:mono_stroke) { {
+      let(:mono_stroke_constructor) { {
         "word": "be",
         "chords": [
           { "bricks": ["end-b"] }
         ]
       } }
+      subject(:mono_stroke) { Definition.new(mono_stroke_constructor, registry, mapper) }
 
-      let(:two_stroke) { {
+      let(:two_stroke_constructor) { {
         "word": "being",
         "chords": [
           { bricks: ["end-b"] },
           { bricks: ["end-g"] }
         ]
       } }
+      subject(:two_stroke) { Definition.new(two_stroke_constructor, registry, mapper) }
 
+      before do
+        allow(registry).to receive(:lookup).with('end-b').and_return(end_b)
+        allow(registry).to receive(:lookup).with('end-g').and_return(end_g)
+        allow(mapper).to receive(:lookup).with(['end-b']).and_return('-b')
+        allow(mapper).to receive(:lookup).with(['end-g']).and_return('-g')
+      end
       it 'can accept "word" and "bricks" for constructor of a mono-stroke definition"' do
-        definition = Definition.new(flat_mono)
-        expect(definition.word).to eql('be')
-        expect(definition.chords.count).to eql(1)
+        expect(flat_mono.word).to eql('be')
+        expect(flat_mono.chords.count).to eql(1)
       end
 
       it 'can accept "word" and "chords" for constructor of a mono-stroke definition"' do
-        definition = Definition.new(mono_stroke)
-        expect(definition.word).to eql('be')
-        expect(definition.chords.count).to eql(1)
+        expect(mono_stroke.word).to eql('be')
+        expect(mono_stroke.chords.count).to eql(1)
       end
 
       it 'can accept "word" and "chords" for constructor of a two-stroke definition"' do
-        definition = Definition.new(two_stroke)
-        expect(definition.word).to eql('being')
-        expect(definition.chords.count).to eql(2)
+        expect(two_stroke.word).to eql('being')
+        expect(two_stroke.chords.count).to eql(2)
       end
-
     end
   end
 end

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -114,6 +114,20 @@ module Steno
     end
 
     describe Chord do
+      describe 'construction' do
+        let(:registry) { double("BrickRegistry") }
+        before do
+          allow(registry).to receive(:lookup).with('soft-e').and_return(soft_e)
+          allow(registry).to receive(:lookup).with('start-b').and_return(start_b)
+          allow(registry).to receive(:lookup).with('end-nch').and_return(end_nch)
+        end
+        it 'can be constructed with [Brick] list or [string_id] list with a registry' do
+          one = Chord.new(['start-b', 'soft-e', 'end-nch'], registry)
+          two = Chord.new([start_b, soft_e, end_nch])
+          expect(one).to eql(two)
+        end
+      end
+
       context "given bricks in wrong order" do
         subject{ Chord.new([soft_e, start_b, end_nch]) }
 

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -154,5 +154,46 @@ module Steno
         end
       end
     end
+
+    describe Definition do
+      let(:flat_mono) { {
+        "word": "be",
+        "bricks": ["end-b"]
+      } }
+
+      let(:mono_stroke) { {
+        "word": "be",
+        "chords": [
+          { "bricks": ["end-b"] }
+        ]
+      } }
+
+      let(:two_stroke) { {
+        "word": "being",
+        "chords": [
+          { bricks: ["end-b"] },
+          { bricks: ["end-g"] }
+        ]
+      } }
+
+      it 'can accept "word" and "bricks" for constructor of a mono-stroke definition"' do
+        definition = Definition.new(flat_mono)
+        expect(definition.word).to eql('be')
+        expect(definition.chords.count).to eql(1)
+      end
+
+      it 'can accept "word" and "chords" for constructor of a mono-stroke definition"' do
+        definition = Definition.new(mono_stroke)
+        expect(definition.word).to eql('be')
+        expect(definition.chords.count).to eql(1)
+      end
+
+      it 'can accept "word" and "chords" for constructor of a two-stroke definition"' do
+        definition = Definition.new(two_stroke)
+        expect(definition.word).to eql('being')
+        expect(definition.chords.count).to eql(2)
+      end
+
+    end
   end
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -23,14 +23,28 @@ describe Validator do
       "keystrokes" => [9]
     }
   }
+  let(:end_b) {
+    {
+      "id" => "end-b",
+      "label" => "B",
+      "keystrokes" => [16]
+    }
+  }
+  let(:end_g) {
+    {
+      "id" => "end-g",
+      "label" => "G",
+      "keystrokes" => [18]
+    }
+  }
 
-  let(:bricks) { [start_t, start_w, short_o] }
+  let(:bricks) { [start_t, start_w, short_o, end_b, end_g] }
   let(:definitions) {[]}
 
   subject { Validator.new('bricks' => bricks, 'definitions' => definitions) }
 
   it '#brick_ids' do
-    expect(subject.brick_ids).to eql(['start-t', 'start-w', 'short-o'])
+    expect(subject.brick_ids).to eql(['start-t', 'start-w', 'short-o', 'end-b', 'end-g'])
   end
 
   context 'when definitions use only bricks that have been defined' do
@@ -41,11 +55,18 @@ describe Validator do
           "start-t",
           "short-o"
         ]
+      },
+      {
+        "word" => "being",
+        "strokes" => [
+          { "bricks" => ["end-b"] },
+          { "bricks" => ["end-g"] }
+        ]
       }
     ]}
 
     it '#used_bricks returns the bricks used by definitions' do
-      expect(subject.used_bricks).to eql(['start-t', 'short-o'])
+      expect(subject.used_bricks).to eql(['start-t', 'short-o', 'end-b', 'end-g'])
     end
 
     it '#undefined_bricks returns []' do


### PR DESCRIPTION
This PR adds support for handling definitions made up from more than one stroke. e.g. JSON for defining the `-b/-g` definition for "being":

```
{
  "word": "being",
  "chords": [
    { "bricks": [ "end-b" ] },
    { "bricks": [ "end-g" ] }
  ]
}
```

The SVG diagrams don't yet know how to handle the extra strokes.
