### PR TITLE
Fix the code that builds a list of Definitions for a given brick

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -109,7 +109,7 @@ end
 
 if data.has_key? :bricks
   data.bricks.each do |brick|
-    definitions = definition_list.select { |defn| defn.bricks.include?(brick.id) }
+    definitions = definition_list.select { |defn| defn.bricks.map(&:id).include?(brick.id) }
     similar = (data.bricks - [brick]).select { |b| b.keystrokes == brick.keystrokes }
 
     proxy "/bricks/#{brick.id}.svg", "/brick.svg",


### PR DESCRIPTION
This PR fixes another bug introduced by the work that introduced multi-stroke definitions.
