### PR TITLE
Make the 'S' key double-width

### DIFF
--- a/lib/steno_brick_kit.rb
+++ b/lib/steno_brick_kit.rb
@@ -68,6 +68,20 @@ module StenoBrickKit
         ]
       },
       {
+        id: 'doubleRowPath',
+        points: [
+          "M #{Dimensions::HORIZONTAL_UNIT*0.0} #{Dimensions::V_STARTER}",
+          "C #{Dimensions::HORIZONTAL_UNIT*0.0} #{Dimensions::V_STARTER + Dimensions::VERTICAL_UNIT_CURVE*-1.0}",
+          "  #{Dimensions::HORIZONTAL_UNIT*1.0} #{Dimensions::V_STARTER + Dimensions::VERTICAL_UNIT_CURVE*-1.0}",
+          "  #{Dimensions::HORIZONTAL_UNIT*1.0} #{Dimensions::V_STARTER}",
+          "L #{Dimensions::HORIZONTAL_UNIT*1.0} #{Dimensions::V_STARTER + Dimensions::BOTTOM_HEIGHT}",
+          "C #{Dimensions::HORIZONTAL_UNIT*1.0} #{Dimensions::V_STARTER + Dimensions::BOTTOM_HEIGHT + Dimensions::VERTICAL_UNIT_CURVE*3.0}",
+          "  #{Dimensions::HORIZONTAL_UNIT*0.0} #{Dimensions::V_STARTER + Dimensions::BOTTOM_HEIGHT + Dimensions::VERTICAL_UNIT_CURVE*3.0}",
+          "  #{Dimensions::HORIZONTAL_UNIT*0.0} #{Dimensions::V_STARTER + Dimensions::BOTTOM_HEIGHT}",
+          "z"
+        ]
+      },
+      {
         id: 'thumbFirstPath',
         points: [
           "M #{Dimensions::HORIZONTAL_UNIT*0.0} #{Dimensions::V_STARTER}",

--- a/lib/steno_keyboard.rb
+++ b/lib/steno_keyboard.rb
@@ -1,7 +1,7 @@
 module Steno
   KEY_INFORMATION = {
     0  => { :label => '#', symbol: '#numberKeyPath',   side: '',      row: '',       finger: '',        left: 0,  right:  2, shade: 'dark',  offset: -0.5 },
-    1  => { :label => 's', symbol: '#bottomRowPath',   side: 'left',  row: 'bottom', finger: 'pinky',   left: 3,  right:  4, shade: 'light', offset: 0.5 },
+    1  => { :label => 's', symbol: '#doubleRowPath',   side: 'left',  row: 'bottom', finger: 'pinky',   left: 2,  right:  4, shade: 'light', offset: 0.5 },
     2  => { :label => 't', symbol: '#topRowPath',      side: 'left',  row: 'top',    finger: 'ring',    left: 4,  right:  5, shade: 'dark',  offset: 1.5 },
     3  => { :label => 'k', symbol: '#bottomRowPath',   side: 'left',  row: 'bottom', finger: 'ring',    left: 5,  right:  6, shade: 'light', offset: 1.5 },
     4  => { :label => 'p', symbol: '#topRowPath',      side: 'left',  row: 'top',    finger: 'middle',  left: 6,  right:  7, shade: 'dark',  offset: 2.5 },

--- a/spec/steno_brick_kit_spec.rb
+++ b/spec/steno_brick_kit_spec.rb
@@ -30,7 +30,7 @@ module StenoBrickKit
     it 'leftBottom' do
       button = StenoBrickKit.leftBottom.first
       expect(button[:shade]).to eql('light')
-      expect(button[:symbol]).to eql('#bottomRowPath')
+      expect(button[:symbol]).to eql('#doubleRowPath')
       expect(button[:offset]).to eql(0.5)
     end
 


### PR DESCRIPTION
Make the left side 'S' key double width.
## Before:

<img width="972" alt="scarlet-skinny-s" src="https://cloud.githubusercontent.com/assets/7069/11914903/0dfabcfe-a686-11e5-9ae0-2e33ad727faf.png">
## After:

<img width="972" alt="scarlet-fat-s" src="https://cloud.githubusercontent.com/assets/7069/11914904/15f2a39a-a686-11e5-8836-ad10b3d4401a.png">
