### PR TITLE
[SPIKE] Explode definitions

### DIFF
--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -1,0 +1,3 @@
+class DefinitionExploder
+
+end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -31,6 +31,20 @@ module NotationMapper
 
 end
 
+class BrickSignatureMap
+  def initialize(bricks)
+    bricks = bricks.map { |b| OpenStruct.new(b) }
+    @dictionary = bricks.each_with_object({}) do |brick, hash|
+      hash[brick.keystrokes] ||= []
+      hash[brick.keystrokes] << brick
+    end
+  end
+
+  def lookup(signature)
+    @dictionary[signature]
+  end
+end
+
 class DefinitionExploder
   attr_reader :brickset
 

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module NotationMapper
   KEY_LABELS = %w(# s t k p w h r a o * e u f r p b l g t s d z)
   #               0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
@@ -55,18 +57,14 @@ class DefinitionExploder
   def explode(notation)
     matches = []
     signature = NotationMapper.translate(notation)
-    portions = signature.size.downto(1).map { |s| signature.combination(s).entries }
-    break_from_portion = false
-    portions.each do |portion|
-      portion.each do |combination|
+    signature.groupings.each do |grouping|
+      grouping.each do |combination|
         if match = @signatures.lookup(combination)
           matches << match
-          break_from_portion = true
         end
       end
-      break if break_from_portion
     end
-    matches
+    matches.take(1)
   end
 end
 

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -73,16 +73,19 @@ end
 class Array
   def groupings
     size.downto(1).flat_map { |s|
-      combination(s).to_a.map { |c|
+      combination(s).to_a.inject([]) { |list, c|
         remainder = self - c
         if remainder.empty?
-          [c]
+          list << [c]
         else
           if c.first < remainder.first
-            [c, remainder]
+            remainder.groupings.flat_map { |g|
+              list << [c] + g
+            }
           end
         end
-      }.compact
+        list
+      }
     }
   end
 end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -67,6 +67,7 @@ end
 
 module Mux
   def self.zip(input)
+    return [input] if input == input.flatten
     target_size = input.map(&:size).inject(1, :*)
     filled = input.map { |i| i.cycle(target_size / i.size).to_a }
     filled.first.zip(*filled.drop(1)).uniq

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -6,10 +6,16 @@ module NotationMapper
   def self.translate(notation)
     left, right = notation.downcase.split('-')
 
-    [
+    numerals = [
       lookup(left.to_s.chars),
       lookup(right.to_s.chars, 10)
     ].flatten
+
+    if numerals.length == notation.sub('-', '').length
+      return numerals
+    else
+      raise "Can't parse notation: '#{notation}'"
+    end
   end
 
   def self.lookup(characters, offset=0)

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -49,8 +49,23 @@ class DefinitionExploder
   attr_reader :brickset
 
   def initialize(bricks)
-    @brickset = bricks.each_with_object({}) do |brick, hash|
-      hash[brick[:id]] = brick[:keystrokes]
+    @signatures = BrickSignatureMap.new(bricks)
+  end
+
+  def explode(notation)
+    matches = []
+    signature = NotationMapper.translate(notation)
+    portions = signature.size.downto(1).map { |s| signature.combination(s).entries }
+    break_from_portion = false
+    portions.each do |portion|
+      portion.each do |combination|
+        if match = @signatures.lookup(combination)
+          matches << match
+          break_from_portion = true
+        end
+      end
+      break if break_from_portion
     end
+    matches
   end
 end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -72,8 +72,17 @@ end
 
 class Array
   def groupings
-    size.downto(1).map { |s|
-      combination(s).to_a
+    size.downto(1).flat_map { |s|
+      combination(s).to_a.map { |c|
+        remainder = self - c
+        if remainder.empty?
+          [c]
+        else
+          if c.first < remainder.first
+            [c, remainder]
+          end
+        end
+      }.compact
     }
   end
 end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -69,3 +69,11 @@ class DefinitionExploder
     matches
   end
 end
+
+class Array
+  def groupings
+    size.downto(1).map { |s|
+      combination(s).to_a
+    }
+  end
+end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -70,6 +70,14 @@ class DefinitionExploder
   end
 end
 
+module Mux
+  def self.zip(input)
+    target_size = input.map(&:size).inject(1, :*)
+    filled = input.map { |i| i.cycle(target_size / i.size).to_a }
+    filled.first.zip(*filled.drop(1)).uniq
+  end
+end
+
 class Array
   def groupings
     size.downto(1).flat_map { |s|

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module NotationMapper
   KEY_LABELS = %w(# s t k p w h r a o * e u f r p b l g t s d z)
   #               0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
@@ -57,14 +55,13 @@ class DefinitionExploder
   def explode(notation)
     matches = []
     signature = NotationMapper.translate(notation)
-    signature.groupings.each do |grouping|
-      grouping.each do |combination|
-        if match = @signatures.lookup(combination)
-          matches << match
-        end
+    signature.groupings.each do |combination|
+      matching_bricks = combination.map { |c| @signatures.lookup(c) }
+      unless matching_bricks.any? { |i| i.nil? }
+        matches << Mux.zip(matching_bricks)
       end
     end
-    matches.take(1)
+    matches
   end
 end
 

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -1,3 +1,13 @@
 class DefinitionExploder
 
 end
+
+class DefinitionExploder
+  attr_reader :brickset
+
+  def initialize(bricks)
+    @brickset = bricks.each_with_object({}) do |brick, hash|
+      hash[brick[:id]] = brick[:keystrokes]
+    end
+  end
+end

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -58,7 +58,7 @@ class DefinitionExploder
     signature.groupings.each do |combination|
       matching_bricks = combination.map { |c| @signatures.lookup(c) }
       unless matching_bricks.any? { |i| i.nil? }
-        matches << Mux.zip(matching_bricks)
+        matches += Mux.zip(matching_bricks)
       end
     end
     matches

--- a/lib/definition_exploder.rb
+++ b/lib/definition_exploder.rb
@@ -1,4 +1,27 @@
-class DefinitionExploder
+module NotationMapper
+  KEY_LABELS = %w(# s t k p w h r a o * e u f r p b l g t s d z)
+  #               0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
+  #                                  10                  20
+
+  def self.translate(notation)
+    left, right = notation.downcase.split('-')
+
+    [
+      lookup(left.to_s.chars),
+      lookup(right.to_s.chars, 10)
+    ].flatten
+  end
+
+  def self.lookup(characters, offset=0)
+    Array.new.tap do |buttons|
+      KEY_LABELS[offset..-1].each_with_index do |button, index|
+        if button == characters.first
+          buttons << (index + offset)
+          characters.shift
+        end
+      end
+    end
+  end
 
 end
 

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -171,14 +171,27 @@ describe DefinitionExploder do
       [OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})]
     ])
 
-    expect(exploder.explode(no_notation)).to eql([
-      [
-        OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
-        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
-      ]
-    ])
+    # expect(exploder.explode(no_notation)).to eql([
+    #   [
+    #     OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
+    #     OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
+    #   ]
+    # ])
   end
 
 end
 
+describe Array do
+  describe '#groupings' do
+    it 'has one result for array.size => 1' do
+      expect(['a'].groupings).to eql([[['a']]])
+    end
 
+    it 'has some results for array.size => 2' do
+      result = ['a', 'b'].groupings.to_a
+      expect(result.size).to eql(2)
+      expect(result).to include([['a', 'b']])
+      expect(result).to include([['a'], ['b']])
+    end
+  end
+end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -1,0 +1,47 @@
+require 'rspec'
+require_relative '../lib/definition_exploder'
+
+describe DefinitionExploder do
+  # "SAF": "save",
+  # "SAEUF": "safe",
+  let(:bricks) do
+    [
+      {
+        "id": "start-s",
+        "label": "S",
+        "keystrokes": [1]
+      },
+      {
+        "id": "short-a",
+        "label": "A",
+        "keystrokes": [8]
+      },
+      {
+        "id": "long-a",
+        "label": "AY",
+        "keystrokes": [8,11,12]
+      },
+      {
+        "id": "end-f",
+        "label": "F",
+        "keystrokes": [13]
+      },
+      {
+        "id": "end-v",
+        "label": "V",
+        "keystrokes": [13]
+      }
+    ]
+  end
+
+  let(:save_chord) { }
+
+  # xit 'works like this' do
+  #   exploder = DefinitionExploder.new(bricks)
+  #   possibilities = exploder.explode(save_chord)
+  #   expect(possibilities).to eql([
+  #     ["start-s", "short-a", "end-f"],
+  #     ["start-s", "short-a", "end-v"],
+  #   ])
+  # end
+end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -181,6 +181,35 @@ describe DefinitionExploder do
 
 end
 
+describe Mux do
+  describe '#zip' do
+    let(:one) { ['a'] }
+    let(:two) { ['m', 'n'] }
+    let(:three) { ['x', 'y', 'z'] }
+
+    it 'combines 1 and 2 element lists' do
+      result = Mux.zip([one, two])
+      expect(result).to include(['a', 'm'])
+      expect(result).to include(['a', 'n'])
+    end
+
+    it 'combines 1, 2 and 3 element lists' do
+      result = Mux.zip([one, two, three])
+      expect(result).to include(['a', 'm', 'x'])
+      expect(result).to include(['a', 'm', 'y'])
+      expect(result).to include(['a', 'm', 'z'])
+      expect(result).to include(['a', 'n', 'x'])
+      expect(result).to include(['a', 'n', 'y'])
+      expect(result).to include(['a', 'n', 'z'])
+    end
+
+    it 'combines 2, 2 and 3 element lists' do
+      result = Mux.zip([two, two, three])
+      expect(result.size).to eql(6)
+    end
+  end
+end
+
 describe Array do
   describe '#groupings' do
     it 'has one result for array.size => 1' do

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -213,6 +213,12 @@ describe Mux do
     let(:two) { ['m', 'n'] }
     let(:three) { ['x', 'y', 'z'] }
 
+    it 'given a single array, nests it as the single item in an outer array' do
+      expect(Mux.zip(one)).to eql([one])
+      expect(Mux.zip(two)).to eql([two])
+      expect(Mux.zip(three)).to eql([three])
+    end
+
     it 'combines 1 and 2 element lists' do
       result = Mux.zip([one, two])
       expect(result).to include(['a', 'm'])

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -2,8 +2,6 @@ require 'rspec'
 require_relative '../lib/definition_exploder'
 
 describe DefinitionExploder do
-  # "SAF": "save",
-  # "SAEUF": "safe",
   let(:bricks) do
     [
       {
@@ -34,14 +32,76 @@ describe DefinitionExploder do
     ]
   end
 
-  let(:save_chord) { }
+  let(:save_notation) { 'SAF' }
+  let(:safe_notation) { 'SAEUF' }
 
-  # xit 'works like this' do
+  it 'works like this' do
+    exploder = DefinitionExploder.new(bricks)
+    possibilities = exploder.explode(save_notation)
+    expect(possibilities).to eql([
+      ["start-s", "short-a", "end-f"],
+      ["start-s", "short-a", "end-v"],
+    ])
+  end
+end
+
+describe DefinitionExploder do
+  let(:bricks) do
+    [
+      {
+        "id": "start-s",
+        "label": "S",
+        "keystrokes": [1]
+      },
+      {
+        "id": "short-a",
+        "label": "A",
+        "keystrokes": [8]
+      },
+      {
+        "id": "long-a",
+        "label": "AY",
+        "keystrokes": [8,11,12]
+      },
+      {
+        "id": "short-e",
+        "label": "E",
+        "keystrokes": [11]
+      },
+      {
+        "id": "short-u",
+        "label": "U",
+        "keystrokes": [12]
+      },
+      {
+        "id": "short-i",
+        "label": "I",
+        "keystrokes": [11,12]
+      },
+      {
+        "id": "end-f",
+        "label": "F",
+        "keystrokes": [13]
+      },
+      {
+        "id": "end-v",
+        "label": "V",
+        "keystrokes": [13]
+      }
+    ]
+  end
+
+  let(:i_notation) { 'EU' }
+  let(:save_notation) { 'SAF' }
+  let(:safe_notation) { 'SAEUF' }
+
+  # it 'works like this' do
   #   exploder = DefinitionExploder.new(bricks)
-  #   possibilities = exploder.explode(save_chord)
+  #   possibilities = exploder.explode(i_notation).map{ |p| p["id"] }
   #   expect(possibilities).to eql([
-  #     ["start-s", "short-a", "end-f"],
-  #     ["start-s", "short-a", "end-v"],
+  #     ["short-i"],
+  #     ["short-e", "short-u"],
   #   ])
   # end
+
 end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -100,6 +100,9 @@ describe DefinitionExploder do
         "label": "N",
         "keystrokes": [2, 4, 6]
       },
+      { id: 'start-t', label: 'T', keystrokes: [2] },
+      { id: 'start-p', label: 'P', keystrokes: [4] },
+      { id: 'start-h', label: 'H', keystrokes: [6] },
       {
         "id": "short-a",
         "label": "A",
@@ -162,18 +165,41 @@ describe DefinitionExploder do
 
   subject(:exploder) { DefinitionExploder.new(bricks) }
 
-  it 'works like this' do
-    expect(exploder.explode(i_notation).first).to eql([
-      [OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})]
-    ])
-
+  it 'returns a single match for "E" notation' do
     expect(exploder.explode(e_notation).first).to eql([
       [OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})]
     ])
+  end
 
-    expect(exploder.explode(no_notation).first).to eql([
+  it 'returns dual matches for "EU" notation' do
+    result = exploder.explode(i_notation)
+
+    expect(result.first).to eql([
+      [OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})]
+    ])
+
+    expect(result).to include([
+      [
+        OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]}),
+        OpenStruct.new({id: 'short-u', label: 'U', keystrokes: [12]}),
+      ]
+    ])
+  end
+
+  it 'returns multiple matches for "TPHO" notation' do
+    result = exploder.explode(no_notation)
+    expect(result.first).to eql([
       [
         OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
+        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
+      ]
+    ])
+
+    expect(result).to include([
+      [
+        OpenStruct.new({id: 'start-t', label: 'T', keystrokes: [2]}),
+        OpenStruct.new({id: 'start-p', label: 'P', keystrokes: [4]}),
+        OpenStruct.new({id: 'start-h', label: 'H', keystrokes: [6]}),
         OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
       ]
     ])

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -45,6 +45,12 @@ describe NotationMapper do
       end
     end
 
+    it 'blows up when provided with invalid notation' do
+      expect { NotationMapper.translate('X') }.to raise_exception("Can't parse notation: 'X'")
+      expect { NotationMapper.translate('UA') }.to raise_exception("Can't parse notation: 'UA'")
+      expect { NotationMapper.translate('-K') }.to raise_exception("Can't parse notation: '-K'")
+      expect { NotationMapper.translate('SSS') }.to raise_exception("Can't parse notation: 'SSS'")
+    end
   end
 end
 

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -167,7 +167,7 @@ describe DefinitionExploder do
 
   it 'returns a single match for "E" notation' do
     expect(exploder.explode(e_notation).first).to eql([
-      [OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})]
+      OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})
     ])
   end
 
@@ -175,33 +175,43 @@ describe DefinitionExploder do
     result = exploder.explode(i_notation)
 
     expect(result.first).to eql([
-      [OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})]
+      OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})
     ])
 
     expect(result).to include([
-      [
-        OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]}),
-        OpenStruct.new({id: 'short-u', label: 'U', keystrokes: [12]}),
-      ]
+      OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]}),
+      OpenStruct.new({id: 'short-u', label: 'U', keystrokes: [12]}),
     ])
   end
 
   it 'returns multiple matches for "TPHO" notation' do
     result = exploder.explode(no_notation)
     expect(result.first).to eql([
-      [
-        OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
-        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
-      ]
+      OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
+      OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
     ])
 
     expect(result).to include([
-      [
-        OpenStruct.new({id: 'start-t', label: 'T', keystrokes: [2]}),
-        OpenStruct.new({id: 'start-p', label: 'P', keystrokes: [4]}),
-        OpenStruct.new({id: 'start-h', label: 'H', keystrokes: [6]}),
-        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
-      ]
+      OpenStruct.new({id: 'start-t', label: 'T', keystrokes: [2]}),
+      OpenStruct.new({id: 'start-p', label: 'P', keystrokes: [4]}),
+      OpenStruct.new({id: 'start-h', label: 'H', keystrokes: [6]}),
+      OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
+    ])
+  end
+
+  it 'returns multiple matches for "SAF" notation' do
+    result = exploder.explode(save_notation)
+
+    expect(result).to include([
+      OpenStruct.new({id: 'start-s', label: 'S', keystrokes: [1]}),
+      OpenStruct.new({id: "short-a", label: "A", keystrokes: [8]}),
+      OpenStruct.new({id: 'end-f',   label: 'F', keystrokes: [13]}),
+    ])
+
+    expect(result).to include([
+      OpenStruct.new({id: 'start-s', label: 'S', keystrokes: [1]}),
+      OpenStruct.new({id: "short-a", label: "A", keystrokes: [8]}),
+      OpenStruct.new({id: 'end-v',   label: 'V', keystrokes: [13]}),
     ])
   end
 

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -103,6 +103,7 @@ describe DefinitionExploder do
       { id: 'start-t', label: 'T', keystrokes: [2] },
       { id: 'start-p', label: 'P', keystrokes: [4] },
       { id: 'start-h', label: 'H', keystrokes: [6] },
+      { id: 'start-l', label: 'L', keystrokes: [6,7] },
       {
         "id": "short-a",
         "label": "A",
@@ -212,6 +213,22 @@ describe DefinitionExploder do
       OpenStruct.new({id: 'start-s', label: 'S', keystrokes: [1]}),
       OpenStruct.new({id: "short-a", label: "A", keystrokes: [8]}),
       OpenStruct.new({id: 'end-v',   label: 'V', keystrokes: [13]}),
+    ])
+  end
+
+  it 'returns multiple matches for "HRUFRPB" notation' do
+    result = exploder.explode(lurch_notation)
+
+    expect(result).to include([
+      OpenStruct.new({id: 'start-l', label: 'L',   keystrokes: [6, 7]}),
+      OpenStruct.new({id: "short-u", label: 'U',   keystrokes: [12]}),
+      OpenStruct.new({id: 'end-rch', label: 'RCH', keystrokes: [13,14,15,16]}),
+    ])
+
+    expect(result).to include([
+      OpenStruct.new({id: 'start-l', label: 'L',   keystrokes: [6, 7]}),
+      OpenStruct.new({id: "short-u", label: 'U',   keystrokes: [12]}),
+      OpenStruct.new({id: 'end-nch', label: 'NCH', keystrokes: [13,14,15,16]}),
     ])
   end
 

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -163,20 +163,20 @@ describe DefinitionExploder do
   subject(:exploder) { DefinitionExploder.new(bricks) }
 
   it 'works like this' do
-    expect(exploder.explode(i_notation)).to eql([
+    expect(exploder.explode(i_notation).first).to eql([
       [OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})]
     ])
 
-    expect(exploder.explode(e_notation)).to eql([
+    expect(exploder.explode(e_notation).first).to eql([
       [OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})]
     ])
 
-    # expect(exploder.explode(no_notation)).to eql([
-    #   [
-    #     OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
-    #     OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
-    #   ]
-    # ])
+    expect(exploder.explode(no_notation).first).to eql([
+      [
+        OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
+        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
+      ]
+    ])
   end
 
 end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -6,12 +6,45 @@ describe NotationMapper do
     it 'converts "ST" to [1, 2]' do
       expect(NotationMapper.translate('ST')).to eql([1, 2])
     end
+
     it 'converts "-TS" to [19, 20]' do
       expect(NotationMapper.translate('-TS')).to eql([19, 20])
     end
+
     it 'converts "STTS" to [1, 2, 19, 20]' do
       expect(NotationMapper.translate('STTS')).to eql([1, 2, 19, 20])
     end
+
+    it 'converts "#STKPWHRAO*EUFRPBLGTSDZ" to [0, 1, 2, ..., 22]' do
+      expect(NotationMapper.translate('#STKPWHRAO*EUFRPBLGTSDZ')).to eql((0..22).to_a)
+    end
+
+    [
+      ['S', 1, 20],
+      ['T', 2, 19],
+      ['R', 7, 14],
+      ['P', 4, 15],
+    ].each do |letter, left, right|
+      it 'treats "#{letter}" and "-#{letter}" differently' do
+        expect(NotationMapper.translate("#{letter}")).to eql([left])
+        expect(NotationMapper.translate("-#{letter}")).to eql([right])
+      end
+    end
+
+    [
+      ['F', 13],
+      ['B', 16],
+      ['L', 17],
+      ['G', 18],
+      ['D', 21],
+      ['Z', 22],
+    ].each do |letter, index|
+      it 'treats "#{letter}" and "-#{letter}" the same' do
+        expect(NotationMapper.translate("#{letter}")).to eql([index])
+        expect(NotationMapper.translate("-#{letter}")).to eql([index])
+      end
+    end
+
   end
 end
 

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -96,9 +96,19 @@ describe DefinitionExploder do
         "keystrokes": [1]
       },
       {
+        "id": "start-n",
+        "label": "N",
+        "keystrokes": [2, 4, 6]
+      },
+      {
         "id": "short-a",
         "label": "A",
         "keystrokes": [8]
+      },
+      {
+        "id": "short-o",
+        "label": "O",
+        "keystrokes": [9]
       },
       {
         "id": "long-a",
@@ -143,17 +153,32 @@ describe DefinitionExploder do
     ]
   end
 
+  let(:e_notation) { 'E' }
   let(:i_notation) { 'EU' }
   let(:save_notation) { 'SAF' }
   let(:safe_notation) { 'SAEUF' }
+  let(:lurch_notation) { 'HRUFRPB' }
+  let(:no_notation) { 'TPHO' }
 
-  # it 'works like this' do
-  #   exploder = DefinitionExploder.new(bricks)
-  #   possibilities = exploder.explode(i_notation).map{ |p| p["id"] }
-  #   expect(possibilities).to eql([
-  #     ["short-i"],
-  #     ["short-e", "short-u"],
-  #   ])
-  # end
+  subject(:exploder) { DefinitionExploder.new(bricks) }
+
+  it 'works like this' do
+    expect(exploder.explode(i_notation)).to eql([
+      [OpenStruct.new({id: 'short-i', label: 'I', keystrokes: [11, 12]})]
+    ])
+
+    expect(exploder.explode(e_notation)).to eql([
+      [OpenStruct.new({id: 'short-e', label: 'E', keystrokes: [11]})]
+    ])
+
+    expect(exploder.explode(no_notation)).to eql([
+      [
+        OpenStruct.new({id: 'start-n', label: 'N', keystrokes: [2,4,6]}),
+        OpenStruct.new({id: "short-o", label: "O", keystrokes: [9]})
+      ]
+    ])
+  end
 
 end
+
+

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -202,7 +202,23 @@ describe Array do
       expect(result).to include([['a', 'c'], ['b']])
       expect(result).to include([['a'], ['b', 'c']])
       expect(result).to_not include([['b', 'c'], ['a']])
-      expect(result.size).to eql(4)
+      expect(result).to include([['a'], ['b'], ['c']])
+      expect(result.size).to eql(5)
+    end
+
+    it 'has some results for array.size => 4' do
+      result = ['a', 'b', 'c', 'd'].groupings.to_a
+      expect(result).to include([['a', 'b', 'c', 'd']])
+      expect(result).to include([['a', 'b', 'c'], ['d']])
+      expect(result).to include([['a', 'b', 'd'], ['c']])
+      expect(result).to include([['a', 'c', 'd'], ['b']])
+      expect(result).to include([["a", "b"], ["c", "d"]])
+      expect(result).to include([["a", "b"], ["c"], ["d"]])
+      expect(result).to include([["a", "c"], ["b", "d"]])
+      expect(result).to include([["a", "c"], ["b"], ["d"]])
+      expect(result).to include([["a", "d"], ["b", "c"]])
+      expect(result).to include([["a", "d"], ["b"], ["c"]])
+      expect(result).to include([["a"], ["b", "c", "d"]])
     end
   end
 end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -189,9 +189,20 @@ describe Array do
 
     it 'has some results for array.size => 2' do
       result = ['a', 'b'].groupings.to_a
-      expect(result.size).to eql(2)
       expect(result).to include([['a', 'b']])
       expect(result).to include([['a'], ['b']])
+      expect(result).not_to include([['b'], ['a']])
+      expect(result.size).to eql(2)
+    end
+
+    it 'has some results for array.size => 3' do
+      result = ['a', 'b', 'c'].groupings.to_a
+      expect(result).to include([['a', 'b', 'c']])
+      expect(result).to include([['a', 'b'], ['c']])
+      expect(result).to include([['a', 'c'], ['b']])
+      expect(result).to include([['a'], ['b', 'c']])
+      expect(result).to_not include([['b', 'c'], ['a']])
+      expect(result.size).to eql(4)
     end
   end
 end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -54,6 +54,39 @@ describe NotationMapper do
   end
 end
 
+describe BrickSignatureMap do
+  let(:bricks) do
+    [
+      { "id": "short-e", "label": "E",   "keystrokes": [11] },
+      { "id": "short-u", "label": "U",   "keystrokes": [12] },
+      { "id": "short-i", "label": "I",   "keystrokes": [11,12] },
+      { "id": "end-f",   "label": "F",   "keystrokes": [13] },
+      { "id": "end-v",   "label": "V",   "keystrokes": [13] },
+      { "id": "end-rch", "label": "RCH", "keystrokes": [13,14,15,16] },
+      { "id": "end-nch", "label": "NCH", "keystrokes": [13,14,15,16] }
+    ]
+  end
+
+  subject(:signatures) { BrickSignatureMap.new(bricks) }
+
+  it 'returns only match for simple cases' do
+    expect(signatures.lookup([11]).map(&:id)).to eql(['short-e'])
+    expect(signatures.lookup([12]).map(&:id)).to eql(['short-u'])
+    expect(signatures.lookup([11, 12]).map(&:id)).to eql(['short-i'])
+  end
+
+  it 'returns multiple matches' do
+    results = signatures.lookup([13]).map(&:id)
+    expect(results).to include('end-f')
+    expect(results).to include('end-v')
+
+    results = signatures.lookup([13, 14, 15, 16]).map(&:id)
+    expect(results).to include('end-rch')
+    expect(results).to include('end-nch')
+  end
+
+end
+
 describe DefinitionExploder do
   let(:bricks) do
     [
@@ -96,6 +129,16 @@ describe DefinitionExploder do
         "id": "end-v",
         "label": "V",
         "keystrokes": [13]
+      },
+      {
+        "id": "end-rch",
+        "label": "RCH",
+        "keystrokes": [13,14,15,16]
+      },
+      {
+        "id": "end-nch",
+        "label": "NCH",
+        "keystrokes": [13,14,15,16]
       }
     ]
   end

--- a/spec/definition_exploder_spec.rb
+++ b/spec/definition_exploder_spec.rb
@@ -1,47 +1,17 @@
 require 'rspec'
 require_relative '../lib/definition_exploder'
 
-describe DefinitionExploder do
-  let(:bricks) do
-    [
-      {
-        "id": "start-s",
-        "label": "S",
-        "keystrokes": [1]
-      },
-      {
-        "id": "short-a",
-        "label": "A",
-        "keystrokes": [8]
-      },
-      {
-        "id": "long-a",
-        "label": "AY",
-        "keystrokes": [8,11,12]
-      },
-      {
-        "id": "end-f",
-        "label": "F",
-        "keystrokes": [13]
-      },
-      {
-        "id": "end-v",
-        "label": "V",
-        "keystrokes": [13]
-      }
-    ]
-  end
-
-  let(:save_notation) { 'SAF' }
-  let(:safe_notation) { 'SAEUF' }
-
-  it 'works like this' do
-    exploder = DefinitionExploder.new(bricks)
-    possibilities = exploder.explode(save_notation)
-    expect(possibilities).to eql([
-      ["start-s", "short-a", "end-f"],
-      ["start-s", "short-a", "end-v"],
-    ])
+describe NotationMapper do
+  describe '#translate' do
+    it 'converts "ST" to [1, 2]' do
+      expect(NotationMapper.translate('ST')).to eql([1, 2])
+    end
+    it 'converts "-TS" to [19, 20]' do
+      expect(NotationMapper.translate('-TS')).to eql([19, 20])
+    end
+    it 'converts "STTS" to [1, 2, 19, 20]' do
+      expect(NotationMapper.translate('STTS')).to eql([1, 2, 19, 20])
+    end
   end
 end
 


### PR DESCRIPTION
Create a `DefinitionExploder` class which can produce a list of possible ways of explaining a steno definition, given a set of bricks. E.g.:

```
> xp = DefinitionExploder.new(data.bricks)

> xp.explode("HOEP").first
 => [#<OpenStruct id="start-h", label="H", keystrokes=[6]>, #<OpenStruct id="long-o", label="OH", keystrokes=[9, 11]>, #<OpenStruct id="end-p", label="P", keystrokes=[15]>]

> xp.explode("POPB").first
 => [#<OpenStruct id="start-p", label="P", keystrokes=[4]>, #<OpenStruct id="short-o", label="O", keystrokes=[9]>, #<OpenStruct id="end-n", label="N", keystrokes=[15, 16]>]

> xp.explode("TKPWEPB").first
 => [#<OpenStruct id="start-g", label="G", keystrokes=[2, 3, 4, 5]>, #<OpenStruct id="short-e", label="E", keystrokes=[11]>, #<OpenStruct id="end-n", label="N", keystrokes=[15, 16]>]

> xp.explode("PW-PB").first
 => [#<OpenStruct id="start-b", label="B", keystrokes=[4, 5]>, #<OpenStruct id="end-n", label="N", keystrokes=[15, 16]>]
```
