### PR TITLE
Show collisions

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -142,7 +142,7 @@ definition_list.each do |definition|
     locals: { definition: definition, bounds: DiagramBounds.new(definition) }, ignore: true
 
   proxy "/definitions/#{definition.notation}.html", "/definition.html",
-    locals: { definition: definition, synonyms: synonyms, homographs: homographs }, ignore: true
+    locals: { definition: definition, synonyms: synonyms, homographs: homographs, collisions: definition.collisions }, ignore: true
 end
 
 wordset.each_pair do |word, definitions|

--- a/data/bricks.json
+++ b/data/bricks.json
@@ -240,6 +240,11 @@
     "keystrokes": [3,6]
   },
   {
+    "id": "end-ch",
+    "label": "CH",
+    "keystrokes": [10,13,15]
+  },
+  {
     "id": "long-a",
     "label": "AY",
     "keystrokes": [8,11,12]

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -1651,6 +1651,22 @@
     ]
   },
   {
+    "word": "lunch",
+    "chords": [
+      {"bricks": ["start-l", "short-u", "end-n"]},
+      {"bricks": ["end-ch"]}
+    ]
+  },
+  {
+    "word": "lunch",
+    "bricks": [
+      "start-l",
+      "short-u",
+      "end-n",
+      "end-s"
+    ]
+  },
+  {
     "word": "lynch",
     "bricks": [
       "start-l",

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -1644,6 +1644,7 @@
   },
   {
     "word": "lift",
+    "collisions": ["list"],
     "bricks": [
       "start-l",
       "short-i",
@@ -1662,6 +1663,7 @@
   },
   {
     "word": "lurch",
+    "collisions": ["lunch"],
     "bricks": [
       "start-l",
       "short-u",

--- a/data/definitions.json
+++ b/data/definitions.json
@@ -1643,6 +1643,24 @@
     ]
   },
   {
+    "word": "lift",
+    "bricks": [
+      "start-l",
+      "short-i",
+      "end-f",
+      "end-t"
+    ]
+  },
+  {
+    "word": "list",
+    "bricks": [
+      "start-l",
+      "star",
+      "short-i",
+      "end-s"
+    ]
+  },
+  {
     "word": "lurch",
     "bricks": [
       "start-l",

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -130,15 +130,17 @@ module Steno
   end
 
   class Definition
-    attr_reader :word, :chords
+    attr_reader :word, :chords, :collisions
 
     def initialize(params, registry=BrickRegistry.new, mapper=nil)
       params = OpenStruct.new(params)
       params.chords ||= []
+      params.collisions ||= []
       if params.bricks
         params.chords << { bricks: params.bricks }
       end
 
+      @collisions = params.collisions
       @word   = params.word
       @chords = params.chords.map { |chord| Chord.new(chord[:bricks], registry, mapper) }
     end

--- a/source/definition.html.erb
+++ b/source/definition.html.erb
@@ -25,3 +25,18 @@ title: Definition page
 
   <%= partial('definitions-table', locals: {definitions: synonyms, active: definition}) %>
 <% end %>
+
+<% unless collisions.empty? %>
+  <h2>Collisions</h2>
+
+  <p>
+    The <%= definition.notation.upcase %> stroke produces the word "<%= definition.word %>".
+    If you look at it another way, this stroke could have produced this/these word(s):
+  </p>
+
+  <ul class="word-list">
+    <% collisions.sort.each do |word| %>
+      <li><%= link_to_word(word) %></li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
Make it so that a definition can be annotated with a list of other words which 'collide', that is, the stroke could just have well have produced another word.

<img width="705" alt="lift-collision" src="https://cloud.githubusercontent.com/assets/7069/12011169/53349840-acbb-11e5-9269-944ffc330d4f.png">
