### PR TITLE
Fix normalize collisions

### DIFF
--- a/data/definitions.json
+++ b/data/definitions.json
@@ -2011,6 +2011,7 @@
   {
     "word": "lift",
     "notation": "HREUFT",
+    "collisions": ["list"],
     "chords": [
       {
         "bricks": [
@@ -2071,6 +2072,7 @@
   {
     "word": "lurch",
     "notation": "HRUFRPB",
+    "collisions": ["lunch"],
     "chords": [
       {
         "bricks": [

--- a/lib/steno.rb
+++ b/lib/steno.rb
@@ -162,10 +162,11 @@ module Steno
     end
 
     def to_h
-      {
-        word: word,
-        notation: notation.upcase,
-        chords: chords.map(&:to_h)
+      Hash.new.tap { |h|
+        h[:word]       = word
+        h[:notation]   = notation.upcase
+        h[:chords]     = chords.map(&:to_h)
+        h[:collisions] = collisions unless collisions.empty?
       }
     end
   end

--- a/spec/steno_spec.rb
+++ b/spec/steno_spec.rb
@@ -193,6 +193,7 @@ module Steno
 
       let(:mono_stroke_constructor) { {
         "word": "be",
+        "collisions": ["bee"],
         "chords": [
           { "bricks": ["end-b"] }
         ]
@@ -248,6 +249,7 @@ module Steno
           expect(mono_stroke.to_h).to eql({
             "word": "be",
             "notation": "-B",
+            "collisions": ["bee"],
             "chords": [
               {
                 "bricks": ["end-b"]


### PR DESCRIPTION
Previously, the `stenobricks normalize` command stripped out the `collisions` field. This patch fixes that and restores lost data.
